### PR TITLE
Fix OG image icon display and title alignment

### DIFF
--- a/app/components/ogimage.tsx
+++ b/app/components/ogimage.tsx
@@ -31,9 +31,12 @@ const nameStyle = {
   fontSize: 50,
 };
 
-const titleStyle = {
+const titleStyle: CSSProperties = {
   fontSize: 50,
   width: "80%",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
 };
 const footerIconStyle = {
   marginRight: "20px",
@@ -62,8 +65,8 @@ const OgImage: FC<Props> = ({ title }) => {
     return (
       <div style={divStyle}>
         <img
-          width="200"
-          height="200"
+          width={200}
+          height={200}
           style={iconStyle}
           src={iconSrc}
           alt="icon"
@@ -78,8 +81,8 @@ const OgImage: FC<Props> = ({ title }) => {
       <p style={titleStyle}>{title}</p>
       <p style={footerStyle}>
         <img
-          width="70"
-          height="70"
+          width={70}
+          height={70}
           style={footerIconStyle}
           src={iconSrc}
           alt="icon"


### PR DESCRIPTION
## Summary
- Fixed OG image icon not displaying by changing img width/height attributes from strings to numbers
- Fixed title alignment to center using flexbox properties

## Changes
1. **Icon display fix**: Changed `width="200"` and `height="70"` to `width={200}` and `height={70}` to resolve satori rendering errors
2. **Title alignment fix**: Added `display: "flex"`, `justifyContent: "center"`, and `alignItems: "center"` to titleStyle for proper center alignment

## Test plan
- [x] Deleted old OG images
- [x] Rebuilt project and verified icons are displayed
- [x] Verified title is center-aligned in generated images
- [x] No build warnings for invalid width/height values

🤖 Generated with [Claude Code](https://claude.com/claude-code)